### PR TITLE
[WIP] Feature/get chess board from api

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -4,6 +4,8 @@ require "json"
 require "uri"
 
 class WebhookController < ApplicationController
+  CHESS_API_URL = 'https://api.chess.com/pub/puzzle'
+
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
   def client
@@ -35,7 +37,7 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           if event.message['text'] == '問題だして'
-            url = URI.parse('https://api.chess.com/pub/puzzle')
+            url = URI.parse(CHESS_API_URL)
 
             begin
               res = Net::HTTP.get_response(url)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -1,4 +1,7 @@
 require 'line/bot'
+require "net/http"
+require "json"
+require "uri"
 
 class WebhookController < ApplicationController
   protect_from_forgery except: [:callback] # CSRF対策無効化
@@ -25,11 +28,13 @@ class WebhookController < ApplicationController
         case event.type
         when Line::Bot::Event::MessageType::Text
           if event.message['text'] == '問題だして'
+            url = "https://api.chess.com/pub/puzzle"
+            res = Net::HTTP.get(URI.parse(url))
+            data = JSON.parse(res, symbolize_names: true)
             message = {
               type: 'image',
-              #　ランダムな猫の画像を返してくれるURL
-              originalContentUrl: 'https://placekitten.com/400/400',
-              previewImageUrl: 'https://placekitten.com/200/200'
+              originalContentUrl: data[:image],
+              previewImageUrl: data[:image]
             }
           else 
             message = {

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -66,4 +66,6 @@ class WebhookController < ApplicationController
     }
     head :ok
   end
+
+  private :client, :get_error_text_object
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -49,10 +49,10 @@ class WebhookController < ApplicationController
                     previewImageUrl: data[:image]
                   }
                 else
-                  message = getErrorTextObject
+                  message = get_error_text_object
                 end
             rescue => e
-              message = getErrorTextObject
+              message = get_error_text_object
             end
           else 
             message = {

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -13,7 +13,7 @@ class WebhookController < ApplicationController
     }
   end
 
-  def getErrorTextObject
+  def get_error_text_object
     return {
       type: 'text',
       text: '問題が発生しました。しばらくしてから試してください'


### PR DESCRIPTION
## 実装の背景・目的

仕様レベル1を完成させるために、[チェスのAPI](https://www.chess.com/news/view/published-data-api#pubapi-daily-puzzle)を叩いて問題のチェスボードを返答するようにした

## やったこと

- APIを呼び出して返ってきたボードの画像で応答するようにした

## 補足

- 作業進行中、随時コメントとか貰えた方がいいのでまずプルリク送りました。

## 質問
- APIをコールするクラスほかの言語とかだとインターフェースを作っておいて実装はDIで流すことでテストの時モックと簡単にすり替えれる & 後でAPIの仕様が変わったり別のAPIを使うことにしても大丈夫な作りにしてるのをよく見るのですが、Rubyだとあんまり見ないらしくて(Ruby歴2日なのでわからないけど)、どうしたらいいのかなって思ってます。
- HTTPクライアントって標準ライブラリそのまま使うことは少ないのかなって思っているのですが、今回はGETをパラメタもつけずに送る要件しかないのでそのまま使っていいかなって思ってます。別の使うとしたらおすすめライブラリありますか。。

## やること
- [x] APIが死んでた時の例外処理
- [ ] APIの呼び方をコントローラー内に書くべきじゃなさそう
