### PR TITLE
Feature/responds to first move

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -16,7 +16,7 @@ class WebhookController < ApplicationController
   end
 
   def get_error_text_object
-    return {
+    {
       type: 'text',
       text: '問題が発生しました。しばらくしてから試してください'
     } 
@@ -36,7 +36,7 @@ class WebhookController < ApplicationController
       move = move[2..-1]
     end
 
-    return move
+    move
   end
 
   def callback

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,9 +22,7 @@ class WebhookController < ApplicationController
     } 
   end
 
-  def get_nth_move moves, n
-    move = moves[n]
-
+  def normalize_move move
     # "1.Ra5" とかの "1." はいらない && 棋譜に "."は登場しない
     if move.include? "."
       move.slice!(0, 2)
@@ -63,7 +61,7 @@ class WebhookController < ApplicationController
             when Net::HTTPSuccess
               data = JSON.parse(res.body, symbolize_names: true)
               moves = get_moves(data[:pgn])
-              answer = get_nth_move(moves, 0)
+              answer = normalize_move(moves[0])
 
               case event.message['text']
               when '問題だして'
@@ -97,5 +95,5 @@ class WebhookController < ApplicationController
     head :ok
   end
 
-  private :client, :get_error_text_object, :get_nth_move, :get_moves
+  private :client, :get_error_text_object, :normalize_move, :get_moves
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -36,7 +36,7 @@ class WebhookController < ApplicationController
 
     #空行の次が指し手
     empty_line_index = lines.find_index('');
-    moves = lines[empty_line_index + 1].split(' ')
+    lines[empty_line_index + 1].split(' ')
   end
 
   def callback

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -61,14 +61,14 @@ class WebhookController < ApplicationController
               when Net::HTTPSuccess
                 data = JSON.parse(res.body, symbolize_names: true)
 
-                if event.message['text'] == '問題だして'
-                  message = {
-                    type: 'image',
-                    originalContentUrl: data[:image],
-                    previewImageUrl: data[:image]
-                  }
-                else 
-                  if event.message['text'] == get_nth_move(data[:pgn], 0)
+                case event.message['text']
+                  when '問題だして'
+                    message = {
+                      type: 'image',
+                      originalContentUrl: data[:image],
+                      previewImageUrl: data[:image]
+                    }
+                  when get_nth_move(data[:pgn], 0)
                     message = {
                       type: 'text',
                       text: '正解！'
@@ -78,7 +78,6 @@ class WebhookController < ApplicationController
                       type: 'text',
                       text: '間違ってる。。'
                     }
-                  end
                 end
               else
                 message = get_error_text_object

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,13 +22,7 @@ class WebhookController < ApplicationController
     } 
   end
 
-  def get_nth_move pgn, n
-    lines = pgn.lines(chomp: true)
-
-    #空行の次が指し手
-    empty_line_index = lines.find_index('');
-    moves = lines[empty_line_index + 1].split(' ')
-
+  def get_nth_move moves, n
     move = moves[n]
 
     # "1.Ra5" とかの "1." はいらない && 棋譜に "."は登場しない
@@ -37,6 +31,14 @@ class WebhookController < ApplicationController
     end
 
     move
+  end
+
+  def get_moves pgn
+    lines = pgn.lines(chomp: true)
+
+    #空行の次が指し手
+    empty_line_index = lines.find_index('');
+    moves = lines[empty_line_index + 1].split(' ')
   end
 
   def callback
@@ -60,6 +62,8 @@ class WebhookController < ApplicationController
             case res
             when Net::HTTPSuccess
               data = JSON.parse(res.body, symbolize_names: true)
+              moves = get_moves(data[:pgn])
+              answer = get_nth_move(moves, 0)
 
               case event.message['text']
               when '問題だして'
@@ -68,7 +72,7 @@ class WebhookController < ApplicationController
                   originalContentUrl: data[:image],
                   previewImageUrl: data[:image]
                 }
-              when get_nth_move(data[:pgn], 0)
+              when answer 
                 message = {
                   type: 'text',
                   text: '正解！'
@@ -93,5 +97,5 @@ class WebhookController < ApplicationController
     head :ok
   end
 
-  private :client, :get_error_text_object, :get_nth_move
+  private :client, :get_error_text_object, :get_nth_move, :get_moves
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -33,7 +33,7 @@ class WebhookController < ApplicationController
 
     # "1.Ra5" とかの "1." はいらない && 棋譜に "."は登場しない
     if move.include? "."
-      move = move[2..-1]
+      move.slice!(0, 2)
     end
 
     move

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -58,30 +58,30 @@ class WebhookController < ApplicationController
           begin
             res = Net::HTTP.get_response(url)
             case res
-              when Net::HTTPSuccess
-                data = JSON.parse(res.body, symbolize_names: true)
+            when Net::HTTPSuccess
+              data = JSON.parse(res.body, symbolize_names: true)
 
-                case event.message['text']
-                  when '問題だして'
-                    message = {
-                      type: 'image',
-                      originalContentUrl: data[:image],
-                      previewImageUrl: data[:image]
-                    }
-                  when get_nth_move(data[:pgn], 0)
-                    message = {
-                      type: 'text',
-                      text: '正解！'
-                    }
-                  else
-                    message = {
-                      type: 'text',
-                      text: '間違ってる。。'
-                    }
-                end
+              case event.message['text']
+              when '問題だして'
+                message = {
+                  type: 'image',
+                  originalContentUrl: data[:image],
+                  previewImageUrl: data[:image]
+                }
+              when get_nth_move(data[:pgn], 0)
+                message = {
+                  type: 'text',
+                  text: '正解！'
+                }
               else
-                message = get_error_text_object
+                message = {
+                  type: 'text',
+                  text: '間違ってる。。'
+                }
               end
+            else
+              message = get_error_text_object
+            end
           rescue => e
             message = get_error_text_object
           end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -22,6 +22,23 @@ class WebhookController < ApplicationController
     } 
   end
 
+  def get_nth_move pgn, n
+    lines = pgn.lines(chomp: true)
+
+    #空行の次が指し手
+    empty_line_index = lines.find_index('');
+    moves = lines[empty_line_index + 1].split(' ')
+
+    move = moves[n]
+
+    # "1.Ra5" とかの "1." はいらない && 棋譜に "."は登場しない
+    if move.include? "."
+      move = move[2..-1]
+    end
+
+    return move
+  end
+
   def callback
     body = request.body.read
 
@@ -69,5 +86,5 @@ class WebhookController < ApplicationController
     head :ok
   end
 
-  private :client, :get_error_text_object
+  private :client, :get_error_text_object, :get_nth_move
 end


### PR DESCRIPTION
## 実装の背景・目的

機能レベル2の実装向けて1手目を送信すると正解か間違いかを送ってくれるようにした

## やったこと

- pgnからn番目の指し手を取り出すメソッドを追加
- APIを叩いて、"問題出して” に対しては写真、それ以外に対しては正誤判定をするように変更

## 補足
指し手が何手もあって長い時、指してに改行が入ることがあるのでpgn最終行をみるだけではだめっぽい。
そのため空行の次の行を読むだけでは読み損ねてる指し手がある可能性はあるけど、今回は1手目にだけ対応するので大丈夫そう
