### PR TITLE
[WIP]Feature/more friendly input

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -5,6 +5,7 @@ require "uri"
 
 class WebhookController < ApplicationController
   CHESS_API_URL = 'https://api.chess.com/pub/puzzle'
+  CHESS_PIECES = ['K', 'Q', 'B', 'N', 'R', 'P']
 
   protect_from_forgery except: [:callback] # CSRF対策無効化
 
@@ -23,9 +24,23 @@ class WebhookController < ApplicationController
   end
 
   def normalize_move move
+    move.strip!
+
     # "1.Ra5" とかの "1." はいらない && 棋譜に "."は登場しない
     if move.include? "."
       move.slice!(0, 2)
+    end
+
+    move = move.delete('x+#')
+
+    #ポーンが省略されてる場合はつける
+    if CHESS_PIECES.none? { |piece| move.include?(piece) }
+      move = move.insert(-3, 'P')
+    end
+
+    #この段階で4文字あったら元の行か列をを表す番号がついてると思われる
+    if move.length == 4
+      move.slice!(0, 1)
     end
 
     move

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -51,11 +51,11 @@ class WebhookController < ApplicationController
 
     # チェックメイトに関する表記は最後の1文字にしかつかない
     check_notation = nil
-    CHECK_NOTATIONS.each { |mark| 
+    CHECK_NOTATIONS.each do |mark| 
       if(move.slice(-1, 1) == mark) 
         check_notation = mark
       end
-    }
+    end
 
     captured = move.include?(CAPTURE_NOTATION)
     
@@ -119,7 +119,7 @@ class WebhookController < ApplicationController
     end
 
     events = client.parse_events_from(body)
-    events.each { |event|
+    events.each do |event|
       case event
       when Line::Bot::Event::Message
         case event.type
@@ -167,7 +167,7 @@ class WebhookController < ApplicationController
           client.reply_message(event['replyToken'], message)
         end
       end
-    }
+    end
     head :ok
   end
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -51,10 +51,8 @@ class WebhookController < ApplicationController
 
     # チェックメイトに関する表記は最後の1文字にしかつかない
     check_notation = nil
-    CHECK_NOTATIONS.each do |mark| 
-      if(move.slice(-1, 1) == mark) 
-        check_notation = mark
-      end
+    if CHECK_NOTATIONS.include?(move.slice(-1, 1))
+      check_notation = move.slice(-1, 1)
     end
 
     captured = move.include?(CAPTURE_NOTATION)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -30,7 +30,8 @@ class WebhookController < ApplicationController
 
     # "1.Ra5" とかの "1." はいらない && 棋譜に "."は登場しない
     if move.include? "."
-      move.slice!(0, 2)
+      last_dot = move.rindex('.', -1)
+      move.slice!(0, last_dot + 1)
     end
 
     #ポーンが省略されてる場合はつける

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -132,7 +132,7 @@ class WebhookController < ApplicationController
             when Net::HTTPSuccess
               data = JSON.parse(res.body, symbolize_names: true)
               moves = get_moves(data[:pgn])
-              puts moves[0]
+              moves[0]
               user_message = event.message['text']
 
               if user_message == '問題だして'

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -87,16 +87,12 @@ class WebhookController < ApplicationController
       end
     end
 
-    if user_move[:check_notation].present?
-      if user_move[:check_notation] != answer_move[:check_notation]
-        return false
-      end
+    if user_move[:check_notation].present? && user_move[:check_notation] != answer_move[:check_notation]
+      return false
     end
 
-    if user_move[:original_location].present?
-      if user_move[:original_location] != answer_move[:original_location]
-        return false
-      end
+    if user_move[:original_location].present? && user_move[:original_location] != answer_move[:original_location]
+      return false
     end
 
     true

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -76,16 +76,16 @@ class WebhookController < ApplicationController
             when Net::HTTPSuccess
               data = JSON.parse(res.body, symbolize_names: true)
               moves = get_moves(data[:pgn])
-              answer = normalize_move(moves[0])
 
-              case event.message['text']
-              when '問題だして'
+              message = event.message['text']
+
+              if message == '問題だして'
                 message = {
                   type: 'image',
                   originalContentUrl: data[:image],
                   previewImageUrl: data[:image]
                 }
-              when answer 
+              elsif normalize_move(message) == normalize_move(moves[0])
                 message = {
                   type: 'text',
                   text: '正解！'

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -87,13 +87,13 @@ class WebhookController < ApplicationController
       end
     end
 
-    if user_move[:check_notation] != nil
+    if user_move[:check_notation].present?
       if user_move[:check_notation] != answer_move[:check_notation]
         return false
       end
     end
 
-    if user_move[:original_location] != nil
+    if user_move[:original_location].present?
       if user_move[:original_location] != answer_move[:original_location]
         return false
       end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -81,6 +81,33 @@ class WebhookController < ApplicationController
     }
   end
 
+  def correct_move?(answer_move, user_move)
+    if answer_move[:piece] + answer_move[:location] != user_move[:piece] + user_move[:location]
+      return false
+    end
+
+    # ユーザーが細かい情報まで打ち込んだ時だけチェックする
+    if user_move[:captured]
+      if !answer_move[:captured]
+        return false
+      end
+    end
+
+    if user_move[:check_notation] != nil
+      if user_move[:check_notation] != answer_move[:check_notation]
+        return false
+      end
+    end
+
+    if user_move[:original_location] != nil
+      if user_move[:original_location] != answer_move[:original_location]
+        return false
+      end
+    end
+
+    true
+  end
+
   def get_moves pgn
     lines = pgn.lines(chomp: true)
 


### PR DESCRIPTION
## 実装の背景・目的

暇つぶしアプリなのでなるべく多くの人が使えるように、棋譜を完璧に書けなくてもいい機能をつけた

## やったこと

- normalize_moveで駒1文字マス2文字(例: Ka1)の形に統一するようにした
- ユーザーが送った答えもAPIからきた答えもnormalizeをかけることで、独特の表記をしてもしなくても正解になるようにした

## キャプチャ

<img width="351" alt="スクリーンショット 2021-03-26 16 26 36" src="https://user-images.githubusercontent.com/53729870/112598078-6a30a480-8e51-11eb-8424-7e4ede6722b0.png">

## 補足

- WIPです
- ユーザーインプット、APIからのインプットともにノーマライズしてるだけなので、本来なら不正解な記号をつけたしても正解になります。(例: チェックメイトじゃない動きなのに最後に `#` をつけたら、正確には不正解だけど正解になる)

- [ ] 今のままだと、ユーザー `#`, `+`, `x`を省いたときに三文字以下になる文字列を送ったら「問題が発生しました」が送り返されるので対処する
